### PR TITLE
reset form data when switching from update to create mode

### DIFF
--- a/app/admin/dashboard/components/createProductForm/index.js
+++ b/app/admin/dashboard/components/createProductForm/index.js
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "@/common/button";
 import { fields } from "./productFields";
 import { handleSubmit } from "../../createproduct/handler";
@@ -15,10 +15,17 @@ const CreateProductForm = ({
   buttonText,
   adminId,
   isUpdating,
+  searchParams,
 }) => {
   const [errors, setErrors] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
+  useEffect(() => {
+    const handle = searchParams.get("handle");
+    if (!handle) {
+      resetForm();
+    }
+  }, [searchParams, resetForm]);
   const router = useRouter();
 
   const handleFormSubmit = async (e) => {

--- a/app/admin/dashboard/createproduct/page.js
+++ b/app/admin/dashboard/createproduct/page.js
@@ -50,6 +50,7 @@ const CreateProductAdmin = () => {
           buttonText={buttonText}
           adminId={adminId}
           isUpdating={isUpdating}
+          searchParams={searchParams}
         />
       </div>
     </div>


### PR DESCRIPTION
### Summary
This PR fixes an issue where the form data was not being cleared when switching from update mode to create mode in the product creation form. Previously, the form would only reset after a page refresh. 

### Changes
- Added a useEffect hook in the `CreateProductForm` component that resets the form whenever the URL changes and the "handle" query parameter is absent.
- Improved user experience by ensuring that the form is automatically cleared when navigating from updating a product to creating a new product.

### Testing
- Verified that the form resets correctly when navigating between update and create modes.
- Tested the form submission process to ensure that it still works as expected after the fix.

### Related Issues
- Resolves the issue where form data was retained when switching from update mode to create mode without a page refresh.
